### PR TITLE
Remove PyCrypto and replace with required pycryptodomex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.5-dev"
   - "3.6"
   - "3.6-dev"
+  - "3.7-dev"
   - "nightly"
 matrix:
   fast_finish: true
   allow_failures:
+  - python: 2.7-dev
+  - python: 3.4-dev
+  - python: 3.5-dev
   - python: 3.6-dev
+  - python: 3.7-dev
   - python: nightly
 branches:
   only:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGELOG for LaunchKey Python SDK
 ==================================
 
+3.2.0
+-----
+
+* Remove PyCrypto
+
 3.1.2
 -----
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ CHANGELOG for LaunchKey Python SDK
 3.2.0
 -----
 
-* Remove PyCrypto
+* Remove PyCrypto and replace with pycryptodomex that is already required by PyJWKEST
 
 3.1.2
 -----

--- a/launchkey/__init__.py
+++ b/launchkey/__init__.py
@@ -1,4 +1,4 @@
-SDK_VERSION = '3.1.2'
+SDK_VERSION = '3.2.0'
 LAUNCHKEY_PRODUCTION = "https://api.launchkey.com"
 VALID_JWT_ISSUER_LIST = ["svc", "dir", "org"]
 JOSE_SUPPORTED_JWE_ALGS = ['RSA-OAEP']

--- a/launchkey/transports/jose_auth.py
+++ b/launchkey/transports/jose_auth.py
@@ -9,8 +9,8 @@ from hashlib import sha256, sha384, sha512, md5
 from time import time
 from calendar import timegm
 from dateutil.parser import parse
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Cipher import PKCS1_OAEP
 import json
 import six
 from jwkest.jwk import RSAKey, import_rsa_key
@@ -44,11 +44,11 @@ class JOSETransport(object):
         self._server_time_difference = None, None
         self._api_public_keys = [], None
 
-        self.jwt_algorithm = self.__verify_supported_algorith(jwt_algorithm, JOSE_SUPPORTED_JWT_ALGS)
-        self.jwe_cek_encryption = self.__verify_supported_algorith(jwe_cek_encryption, JOSE_SUPPORTED_JWE_ALGS)
-        self.jwe_claims_encryption = self.__verify_supported_algorith(jwe_claims_encryption, JOSE_SUPPORTED_JWE_ENCS)
-        self.content_hash_algorithm = self.__verify_supported_algorith(content_hash_algorithm,
-                                                                       JOSE_SUPPORTED_CONTENT_HASH_ALGS)
+        self.jwt_algorithm = self.__verify_supported_algorithm(jwt_algorithm, JOSE_SUPPORTED_JWT_ALGS)
+        self.jwe_cek_encryption = self.__verify_supported_algorithm(jwe_cek_encryption, JOSE_SUPPORTED_JWE_ALGS)
+        self.jwe_claims_encryption = self.__verify_supported_algorithm(jwe_claims_encryption, JOSE_SUPPORTED_JWE_ENCS)
+        self.content_hash_algorithm = self.__verify_supported_algorithm(content_hash_algorithm,
+                                                                        JOSE_SUPPORTED_CONTENT_HASH_ALGS)
 
         if self.content_hash_algorithm == "S256":
             self.content_hash_function = sha256
@@ -60,7 +60,7 @@ class JOSETransport(object):
         self._http_client = http_client if http_client is not None else RequestsTransport()
 
     @staticmethod
-    def __verify_supported_algorith(algorithm, supported_list):
+    def __verify_supported_algorithm(algorithm, supported_list):
         """Verifies an input string algorithm is in an input list, and raises the appropriate exception if it is not"""
         if algorithm not in supported_list:
             raise InvalidAlgorithm("Input algorithm {0} is not in the supported list of {1}"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 requires = [
     'requests >= 2.5.1, < 3.0.0',
     'six >= 1.10.0, < 2.0.0',
-    'pycrypto >= 2.6.1, < 3.0.0',
     'python-dateutil >= 2.4.2, < 3.0.0',
     'formencode >= 1.3.1, < 2.0.0',
     'pyjwkest >= 1.3.2, < 2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requires = [
     'python-dateutil >= 2.4.2, < 3.0.0',
     'formencode >= 1.3.1, < 2.0.0',
     'pyjwkest >= 1.3.2, < 2.0.0',
+    'pycryptodomex >= 3.4.12, < 4.0.0',
     'pytz'
     ]
 


### PR DESCRIPTION
PyCrypto is no longer considered appropriate. PyJWKEST already uses pycryptodomex. Switch code to use pycryptodomex instead of PyCrypto.
Also fixed typo in internal class method in JOSE auth transport