### PR TITLE
Ensure Postal Code within `TerritoryFence` is not converted to string when it's value is `None`

### DIFF
--- a/launchkey/__init__.py
+++ b/launchkey/__init__.py
@@ -1,5 +1,5 @@
 """LaunchKey Service SDK module"""
-SDK_VERSION = '3.6.0-alpha.3'
+SDK_VERSION = '3.6.0-alpha.4'
 LAUNCHKEY_PRODUCTION = "https://api.launchkey.com"
 VALID_JWT_ISSUER_LIST = ["svc", "dir", "org"]
 JOSE_SUPPORTED_JWE_ALGS = ['RSA-OAEP']

--- a/launchkey/entities/service/policy.py
+++ b/launchkey/entities/service/policy.py
@@ -289,7 +289,7 @@ class TerritoryFence(Fence):
         super(TerritoryFence, self).__init__(name)
         self.country = country
         self.administrative_area = administrative_area
-        self.postal_code = str(postal_code)
+        self.postal_code = str(postal_code) if postal_code else None
 
     def __repr__(self):
         return "TerritoryFence <" \

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1116,3 +1116,16 @@ class TestTerritoryFence(unittest.TestCase):
         expected = "TerritoryFence <country=\"US\", administrative_area=" \
                    "\"US-CA\", postal_code=\"90145\", name=\"TestTerritory\">"
         self.assertEqual(repr(territory_fence), expected)
+
+    def test_postal_code_integer_is_converted_to_string(self):
+        expected = "90145"
+        territory_fence = TerritoryFence("US", "US-CA", 90145, "TestTerritory")
+        fence_dict = dict(territory_fence)
+        self.assertEqual(territory_fence, expected)
+        self.assertEqual(fence_dict["postal_code"], expected)
+
+    def test_postal_code_of_none_is_not_converted_to_string(self):
+        territory_fence = TerritoryFence("US", "US-CA", None, "TestTerritory")
+        fence_dict = dict(territory_fence)
+        self.assertIsNone(territory_fence.postal_code)
+        self.assertIsNone(fence_dict["postal_code"])

--- a/tests/test_service_client.py
+++ b/tests/test_service_client.py
@@ -1121,7 +1121,7 @@ class TestTerritoryFence(unittest.TestCase):
         expected = "90145"
         territory_fence = TerritoryFence("US", "US-CA", 90145, "TestTerritory")
         fence_dict = dict(territory_fence)
-        self.assertEqual(territory_fence, expected)
+        self.assertEqual(territory_fence.postal_code, expected)
         self.assertEqual(fence_dict["postal_code"], expected)
 
     def test_postal_code_of_none_is_not_converted_to_string(self):


### PR DESCRIPTION
### JIRA reference: [LK-4614](https://iovation.atlassian.net/browse/LK-4614)