### PR TITLE
Update Policy Examples and Fix AuthorizationResponse Parsing

### DIFF
--- a/examples/flask-webhooks-example/instance/example_config.py
+++ b/examples/flask-webhooks-example/instance/example_config.py
@@ -9,3 +9,4 @@ ORGANIZATION_ID = "28a8c483-f1a2-4015-adbb-a31e6ea18b90"
 ORGANIZATION_KEY = open("/path/to/private.key").read()
 DIRECTORY_ID = "e243bf77-9966-4fbd-90ed-bb7f4405d9cf"
 SERVICE_ID = "babdb1b5-cb52-4231-9e72-c72732a47c00"
+USE_ADVANCED_WEBHOOKS = True

--- a/examples/flask-webhooks-example/launchkey_example_app/__init__.py
+++ b/examples/flask-webhooks-example/launchkey_example_app/__init__.py
@@ -25,7 +25,8 @@ launchkey_service = LaunchKeyService(
     app.config['ORGANIZATION_KEY'],
     app.config['DIRECTORY_ID'],
     app.config['SERVICE_ID'],
-    app.config.get('LAUNCHKEY_API', LAUNCHKEY_PRODUCTION)
+    app.config.get('LAUNCHKEY_API', LAUNCHKEY_PRODUCTION),
+    app.config.get("USE_ADVANCED_WEBHOOKS", False)
 )
 
 launchkey_service.update_directory_webhook_url(

--- a/examples/flask-webhooks-example/launchkey_example_app/services/launchkey_service.py
+++ b/examples/flask-webhooks-example/launchkey_example_app/services/launchkey_service.py
@@ -3,7 +3,7 @@ from launchkey.factories import OrganizationFactory
 
 class LaunchKeyService:
     def __init__(self, organization_id, organization_key, directory_id,
-                 service_id, launchkey_url):
+                 service_id, launchkey_url, use_advanced_webhooks):
         self.organization_id = organization_id
         self.directory_id = directory_id
         self.service_id = service_id
@@ -21,6 +21,8 @@ class LaunchKeyService:
         self.service_client = organization_factory.make_service_client(
             service_id
         )
+
+        self.use_advanced_webhooks = use_advanced_webhooks
 
     def update_directory_webhook_url(self, webhook_url):
         self.organization_client.update_directory(
@@ -54,7 +56,10 @@ class LaunchKeyService:
         self.service_client.session_end(username)
 
     def handle_service_webhook(self, body, headers, method, path):
-        return self.service_client.handle_webhook(body, headers, method, path)
+        if self.use_advanced_webhooks:
+            return self.service_client.handle_advanced_webhook(body, headers, method, path)
+        else:
+            return self.service_client.handle_webhook(body, headers, method, path)
 
     def handle_directory_webhook(self, body, headers, method, path):
         return self.directory_client.handle_webhook(body, headers, method, path)

--- a/examples/flask-webhooks-example/launchkey_example_app/views/__init__.py
+++ b/examples/flask-webhooks-example/launchkey_example_app/views/__init__.py
@@ -2,7 +2,7 @@ from flask import session, request, render_template, redirect, abort
 from flask.views import MethodView
 
 from launchkey.entities.directory import DeviceLinkCompletionResponse
-from launchkey.entities.service import AuthorizationResponse, SessionEndRequest
+from launchkey.entities.service import AuthorizationResponse, AdvancedAuthorizationResponse, SessionEndRequest
 from launchkey.exceptions import AuthorizationInProgress
 
 
@@ -165,7 +165,8 @@ class ServiceWebhookView(MethodView):
     def post(self):
         package = self.launchkey_service.handle_service_webhook(
             request.data, request.headers, request.method, request.path)
-        if isinstance(package, AuthorizationResponse):
+        if isinstance(package, AdvancedAuthorizationResponse) or isinstance(package, AuthorizationResponse):
+            self.logger.info(f"Service Webhook Received {type(package)}")
             auth_request = self.database_service.get_auth_request(
                 package.authorization_request_id)
             if auth_request:

--- a/launchkey/entities/service/__init__.py
+++ b/launchkey/entities/service/__init__.py
@@ -780,16 +780,22 @@ class AuthorizationResponse(AdvancedAuthorizationResponse):
                         "Invalid policy type given: %s. "
                         "It will be ignored, but this could "
                         "signify the need for an update." % type)
-
         if auth_policy.get('geofences') or kwargs:
             self.auth_policy = AuthPolicy(**kwargs)
             for fence in auth_policy.get('geofences', []):
-                self.auth_policy.add_geofence(
-                    fence['latitude'],
-                    fence['longitude'],
-                    fence['radius'],
-                    name=fence['name']
-                )
+                if not fence.get("type") or fence.get("type") == "GEO_CIRCLE":
+                    self.auth_policy.add_geofence(
+                        fence['latitude'],
+                        fence['longitude'],
+                        fence['radius'],
+                        name=fence.get('name', None)
+                    )
+                else:
+                    warnings.warn(
+                        "A Fence besides GeoCircleFence was present"
+                        " while using legacy functionality. This fence "
+                        "has been skipped from being processed."
+                    )
 
 
 class SessionEndRequest(object):

--- a/tests/test_entities_service.py
+++ b/tests/test_entities_service.py
@@ -450,7 +450,6 @@ class TestAdvancedAuthorizationResponse(unittest.TestCase):
         with self.assertRaises(ValueError):
             AdvancedAuthorizationResponse(self.data, self.transport)
 
-
 @ddt
 class TestAuthorizationResponseAuthPolicy(unittest.TestCase):
 
@@ -576,6 +575,31 @@ class TestAuthorizationResponseAuthPolicy(unittest.TestCase):
             response.auth_policy.minimum_requirements,
             ['knowledge']
         )
+        warnings_patch.warn.assert_called()
+
+    @patch("launchkey.entities.service.warnings")
+    def test_territory_fence_logs_warning(self, warnings_patch):
+        json_data = {
+            "auth_request": "62e09ff8-f9a9-11e8-bbe2-0242ac130008",
+            "type": "AUTHORIZED",
+            "reason": "APPROVED",
+            "denial_reason": "32",
+            "service_pins": ["1", "2", "3"],
+            "device_id": "31e5b804-f9a7-11e8-97ef-0242ac130008",
+            "auth_policy": {
+                "requirement": "cond_geo",
+                "geofences": [{
+                    'country': 'US',
+                    'name': 'UnitedStatesNVPostalCode',
+                    'administrative_area': 'US-NV',
+                    'type': 'TERRITORY',
+                    'postal_code': '89169'
+                }]
+            }
+        }
+
+        self.json_loads_patch.return_value = json_data
+        response = AuthorizationResponse(self.data, self.transport)
         warnings_patch.warn.assert_called()
 
     def test_amount_requirement(self):


### PR DESCRIPTION
* Updated the example CLI and webhook app to allow the ability to call the advanced methods
* Bugfix: AuthorizationResponse now warns the user if the policy contains a TerritoryFence instead of throwing an unhandled exception LK-4690