### PR TITLE
Properly Report Key Utilized in Signing/Encrypting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 CHANGELOG for LaunchKey Python SDK
 ==================================
+3.8.1
+-----
+
+* Fixed an issue where the SDK would improperly report which key was used when the encryption and signature keys differed
 
 3.8.0
 -----

--- a/launchkey/__init__.py
+++ b/launchkey/__init__.py
@@ -1,5 +1,5 @@
 """LaunchKey Service SDK module"""
-SDK_VERSION = '3.8.1-rc1'
+SDK_VERSION = '3.8.1-rc.1'
 LAUNCHKEY_PRODUCTION = "https://api.launchkey.com"
 VALID_JWT_ISSUER_LIST = ["svc", "dir", "org"]
 JOSE_SUPPORTED_JWE_ALGS = ['RSA-OAEP']

--- a/launchkey/__init__.py
+++ b/launchkey/__init__.py
@@ -1,5 +1,5 @@
 """LaunchKey Service SDK module"""
-SDK_VERSION = '3.8.0'
+SDK_VERSION = '3.8.1rc1'
 LAUNCHKEY_PRODUCTION = "https://api.launchkey.com"
 VALID_JWT_ISSUER_LIST = ["svc", "dir", "org"]
 JOSE_SUPPORTED_JWE_ALGS = ['RSA-OAEP']

--- a/launchkey/__init__.py
+++ b/launchkey/__init__.py
@@ -1,5 +1,5 @@
 """LaunchKey Service SDK module"""
-SDK_VERSION = '3.8.1rc1'
+SDK_VERSION = '3.8.1-rc1'
 LAUNCHKEY_PRODUCTION = "https://api.launchkey.com"
 VALID_JWT_ISSUER_LIST = ["svc", "dir", "org"]
 JOSE_SUPPORTED_JWE_ALGS = ['RSA-OAEP']

--- a/launchkey/transports/jose_auth.py
+++ b/launchkey/transports/jose_auth.py
@@ -148,7 +148,11 @@ class JOSETransport(object):
         :param response: Response object
         :return: string of the `kid`
         """
-        return self.__get_kid_from_api_response_headers(response.headers)
+        try:
+            return response.headers["X-IOV-KEY-ID"]
+        except KeyError:
+            raise UnexpectedAPIResponse("X-IOV-KEY-ID was missing or malformed"
+                                        " in API response.")
 
     @staticmethod
     def parse_api_time(api_time):

--- a/launchkey/transports/jose_auth.py
+++ b/launchkey/transports/jose_auth.py
@@ -141,7 +141,8 @@ class JOSETransport(object):
 
         return kid
 
-    def _get_kid_from_api_response(self, response):
+    @staticmethod
+    def _get_kid_from_api_response(response):
         """
         Gets `kid` property from a JWT token within a LaunchKey API
         response.


### PR DESCRIPTION
Fixed an issue where the SDK would improperly report the key used when the encryption and signature keys for API differed