### PR TITLE
Bugfix for JWT signature validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ CHANGELOG for LaunchKey Python SDK
 -----
 
 * Fixed an issue where the SDK would improperly report which key was used when the encryption and signature keys differed
+* Fixed an issue where the SDK would fail to validate webhook signature verification if the signature key was not the one returned in the public-key endpoint
 
 3.8.0
 -----

--- a/launchkey/transports/jose_auth.py
+++ b/launchkey/transports/jose_auth.py
@@ -572,7 +572,10 @@ class JOSETransport(object):
         :return: The claims of the JWT
         """
         try:
-            self._set_current_kid()
+            # Ensure key exists in cache, fetch from API by ID otherwise
+            kid = JWT().unpack(compact_jwt).headers["kid"]
+            public_key = self._find_key_by_kid(kid)
+            self._cache_public_key(kid, public_key)
             payload = self._get_jwt_payload(compact_jwt)
         except JWKESTException as reason:
             raise JWTValidationFailure("Unable to parse JWT", reason=reason)


### PR DESCRIPTION
Fixed an issue where the SDK would fail to validate webhook signature verification if the signature key was not the one returned in the /public/v3/public-key endpoint