### PR TITLE
Update Github Actions Python versions to minimum of 3.7

### DIFF
--- a/.github/workflows/release_integration_tests.yml
+++ b/.github/workflows/release_integration_tests.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         python -m pip install --upgrade pipenv
-        pipenv install --three --dev --ignore-pipfile
+        pipenv install --python 3.7 --dev --ignore-pipfile
     - name: Create environment file
       shell: bash
       run: |

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         python -m pip install --upgrade pipenv
-        pipenv install --three --dev --ignore-pipfile
+        pipenv install --python 3.7 --dev --ignore-pipfile
     - name: Create environment file
       shell: bash
       run: |

--- a/.github/workflows/test_python_versions.yml
+++ b/.github/workflows/test_python_versions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.7]
+        python-version: [3.7, 3.8, 3.9, '3.10', pypy-3.7]
         os: ['ubuntu-latest', 'macos-latest']
       fail-fast: false
     steps:
@@ -47,7 +47,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         python -m pip install --upgrade pipenv
-        pipenv install --dev --ignore-pipfile
+        pipenv install --python 3.7 --dev --ignore-pipfile
     - name: Run Coverage
       run: |
         pipenv run coverage run --source="launchkey" setup.py nosetests

--- a/.github/workflows/test_python_versions.yml
+++ b/.github/workflows/test_python_versions.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, pypy-3.6]
+        python-version: [3.7, 3.8, 3.9, 3.10, pypy-3.7]
         os: ['ubuntu-latest', 'macos-latest']
       fail-fast: false
     steps:
@@ -24,10 +24,10 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Run Unit Tests
       run: |
         python -m pip install --upgrade pip wheel
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/Pipfile
+++ b/Pipfile
@@ -24,4 +24,4 @@ pyhamcrest = "*"
 pyotp = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"


### PR DESCRIPTION
### Summary

- Removes mentions of Python 3.6 for any Github Actions flow
- Adds Python 3.10 to build/test flow
- Installs specifically Python 3.7 for integration test and CI flows